### PR TITLE
Create optional "onSchemaChanged" prop for schema editor component

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",

--- a/src/components/Schema.tsx
+++ b/src/components/Schema.tsx
@@ -14,7 +14,7 @@ export interface ISchemaProps {
   source?: string | File
   schema: IDict | File
   onSave: any
-  onSchemaChanged?: (schema: any, error: any) => void
+  onSchemaChange?: (schema: any, error: any) => void
   disablePreview: boolean
   disableSave?: boolean
 }
@@ -48,9 +48,9 @@ export function Schema(props: ISchemaProps) {
   )
 
   useEffect(() => {
-    if (props.onSchemaChanged) {
+    if (props.onSchemaChange) {
       const schema = memoizedExportSchema()
-      props.onSchemaChanged(schema, error)
+      props.onSchemaChange(schema, error)
     }
   }, [columns, metadata, error])
 

--- a/src/components/Schema.tsx
+++ b/src/components/Schema.tsx
@@ -1,6 +1,6 @@
 import { find } from 'lodash'
 import classNames from 'classnames'
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { arrayMove } from 'react-sortable-hoc'
 import { useAsyncEffect } from 'use-async-effect'
 import { SortableContainer, SortableElement } from 'react-sortable-hoc'
@@ -14,7 +14,9 @@ export interface ISchemaProps {
   source?: string | File
   schema: IDict | File
   onSave: any
+  onSchemaChanged?: (schema: any, error: any) => void
   disablePreview: boolean
+  disableSave: boolean
 }
 
 export function Schema(props: ISchemaProps) {
@@ -40,10 +42,22 @@ export function Schema(props: ISchemaProps) {
     }
   }, [])
 
+  const memoizedExportSchema = useCallback(
+    () => helpers.exportSchema(columns, metadata),
+    [columns, metadata]
+  )
+
+  useEffect(() => {
+    if (props.onSchemaChanged) {
+      const schema = memoizedExportSchema()
+      props.onSchemaChanged(schema, error)
+    }
+  }, [columns, metadata, error])
+
   // Save
   const saveSchema = () => {
     if (props.onSave) {
-      const schema = helpers.exportSchema(columns, metadata)
+      const schema = memoizedExportSchema()
       props.onSave(schema, error)
     }
   }
@@ -76,6 +90,8 @@ export function Schema(props: ISchemaProps) {
     setColumns([...arrayMove(columns, props.oldIndex, props.newIndex)])
   }
 
+  const showTabNumber = !props.disablePreview && !props.disableSave
+
   return (
     <div className="frictionless-components-schema">
       <div className="tableschema-ui-editor-schema">
@@ -97,7 +113,7 @@ export function Schema(props: ISchemaProps) {
               }}
             >
               {!error ? (
-                <span>{!props.disablePreview && <small>1. </small>}Edit</span>
+                <span>{showTabNumber && <small>1. </small>}Edit</span>
               ) : (
                 <span>Error</span>
               )}
@@ -115,13 +131,13 @@ export function Schema(props: ISchemaProps) {
                   setTab('preview')
                 }}
               >
-                <small>2. </small>Preview
+                {showTabNumber && <small>2. </small>}Preview
               </a>
             </li>
           )}
 
           {/* Save/Close */}
-          {!loading && (
+          {!loading && !props.disableSave && (
             <li className="nav-item">
               <a
                 className="nav-link button-save"
@@ -133,7 +149,7 @@ export function Schema(props: ISchemaProps) {
                 }}
               >
                 {!error ? (
-                  <span>{!props.disablePreview && <small>3. </small>}Save</span>
+                  <span>{showTabNumber && <small>3. </small>}Save</span>
                 ) : (
                   <span>Close</span>
                 )}

--- a/src/components/Schema.tsx
+++ b/src/components/Schema.tsx
@@ -16,7 +16,7 @@ export interface ISchemaProps {
   onSave: any
   onSchemaChanged?: (schema: any, error: any) => void
   disablePreview: boolean
-  disableSave: boolean
+  disableSave?: boolean
 }
 
 export function Schema(props: ISchemaProps) {


### PR DESCRIPTION
# Overview

I wanted to use this component, however I wanted to be able to see my schema object change "live" as I edited it.  I was able to accomplish this by passing in an optional "onSchemaChanged" lambda which gets triggered on any change to `columns` or `metadata`.

When using this functionality, I no longer needed the "save" tab, so I made a prop to make that tab hideable just like the "Preview" tab.

Finally, I changed the peer dependencies for React to be >= 17.0.0 so that users (namely, myself) did not have to use the `--legacy-peer-deps` flag.

If there's anything in here you don't want and would rather I remove from this PR, I'm happy to do that and just leave in what you are interested in.

Thanks!
 
---

Please preserve this line to notify @roll (lead of this repository)
